### PR TITLE
Allow error-handing in MacroMirror derivation

### DIFF
--- a/src/test/scala/quotidian/MacroMirrorSpec.scala
+++ b/src/test/scala/quotidian/MacroMirrorSpec.scala
@@ -27,6 +27,10 @@ object MacroMirrorSpec extends ZIOSpecDefault:
       test("construct a singleton type case class") {
         val result = MacroMirrorSpecMacro.constructProductTest[Job.Lump.type]()
         assertTrue(result == Job.Lump)
+      },
+      test("refust to derive a mirror for primitive type") {
+        val result = MacroMirrorSpecMacro.macroMirrorTest[Int]
+        assertTrue(result == "Cannot summon Mirror.Of[scala.Int]")
       }
     )
   )

--- a/src/test/scala/quotidian/MacroMirrorSpecMacro.scala
+++ b/src/test/scala/quotidian/MacroMirrorSpecMacro.scala
@@ -3,27 +3,31 @@ package quotidian
 import scala.quoted.*
 
 object MacroMirrorSpecMacro:
-  inline def macroMirrorTest[A]: Unit               = ${ macroMirrorTestImpl[A] }
+  inline def macroMirrorTest[A]: String               = ${ macroMirrorTestImpl[A] }
   inline def constructProductTest[A](args: Any*): A = ${ constructProductTestImpl[A]('args) }
 
-  def macroMirrorTestImpl[A: Type](using Quotes): Expr[A] =
+  def macroMirrorTestImpl[A: Type](using Quotes): Expr[String] =
     import quotes.reflect.*
     MacroMirror.summon[A] match
-      case singletonMirror: MacroMirror.SingletonMacroMirror[?, ?] =>
-        report.errorAndAbort(s"MacroMirror: $singletonMirror\n${singletonMirror.expr.show}")
-      case productMirror: MacroMirror.ProductMacroMirror[?, ?] =>
-        report.errorAndAbort(s"MacroMirror: $productMirror")
-      case sumMirror: MacroMirror.SumMacroMirror[?, ?] =>
-        report.errorAndAbort(s"MacroMirror: $sumMirror\nordinalOfBanana: ${sumMirror.ordinal[Fruit.Orange]}")
+      case Right(singletonMirror: MacroMirror.SingletonMacroMirror[?, ?]) =>
+        Expr(s"MacroMirror: $singletonMirror\n${singletonMirror.expr.show}")
+      case Right(productMirror: MacroMirror.ProductMacroMirror[?, ?]) =>
+        Expr(s"MacroMirror: $productMirror")
+      case Right(sumMirror: MacroMirror.SumMacroMirror[?, ?]) =>
+        Expr(s"MacroMirror: $sumMirror\nordinalOfBanana: ${sumMirror.ordinal[Fruit.Orange]}")
+      case Left(error) =>
+        Expr(error)
 
   def constructProductTestImpl[A: Type](args: Expr[Seq[Any]])(using Quotes): Expr[A] =
     import quotes.reflect.*
     MacroMirror.summon[A] match
-      case productMirror: MacroMirror.ProductMacroMirror[quotes.type, A] =>
+      case Right(productMirror: MacroMirror.ProductMacroMirror[quotes.type, A]) =>
         val argsExpr = args.asTerm.underlyingArgument.asExprOf[Seq[Any]]
         val argsList = argsExpr match
           case Varargs(args) => args
         val argTerms = argsList.map(_.asTerm)
         productMirror.construct(argTerms)
-      case otherMirror =>
+      case Right(otherMirror) =>
         report.errorAndAbort(s"`constructProductTest` can only be used with product types, but got $otherMirror")
+      case Left(error) =>
+        report.errorAndAbort(error)


### PR DESCRIPTION
My use-case of MacroMirror is to recursively derive a type class instance for case classes, until I hit a primitive type or enum, where I attempt to derive another type class. With current implementation I cannot branch this derivation because `errorAndReport` gets called.

Not sure if the breaking change is allowed, but I assumed it is since we're on 0.0.x branch.